### PR TITLE
NullPointerException in emulator

### DIFF
--- a/vitamio/src/io/vov/vitamio/utils/CPU.java
+++ b/vitamio/src/io/vov/vitamio/utils/CPU.java
@@ -97,14 +97,16 @@ public class CPU {
 			}
 
 			val = cpuinfo.get("Processor");
-			if (val != null && val.contains("(v7l)") || val.contains("ARMv7")) {
-				hasARMv6 = true;
-				hasARMv7 = true;
-			}
-			if (val != null && val.contains("(v6l)") || val.contains("ARMv6")) {
-				hasARMv6 = true;
-				hasARMv7 = false;
-			}
+			if (val != null) {
+                		if (val.contains("(v7l)") || val.contains("ARMv7")) {
+                    			hasARMv6 = true;
+                    			hasARMv7 = true;
+                		}
+                		if (val.contains("(v6l)") || val.contains("ARMv6")) {
+			                hasARMv6 = true;
+                    			hasARMv7 = false;
+                		}
+            		}
 
 			if (hasARMv6)
 				cachedFeature |= FEATURE_ARM_V6;


### PR DESCRIPTION
It cause null pointer exception in emulators and prevent correct initialization in supported emulators. With the fix, the engine is initialized (Android 4.0.2 ARM Emulator)
