### PR TITLE
Remove the black bar when in VIDEO_LAYOUT_SCALE mode.

### DIFF
--- a/vitamio/src/io/vov/vitamio/utils/ScreenResolution.java
+++ b/vitamio/src/io/vov/vitamio/utils/ScreenResolution.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ * Copyright (C) 2013 YIXIA.COM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vov.vitamio.utils;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.util.Pair;
+import android.view.Display;
+import android.view.WindowManager;
+
+import java.lang.reflect.Method;
+
+/**
+ * Class to get the real screen resolution includes the system status bar.
+ * We can get the value by calling the getRealMetrics method if API >= 17
+ * Reflection needed on old devices..
+ * */
+public class ScreenResolution {
+  /**
+   * Gets the resolution,
+   * @return a pair to return the width and height
+   * */
+  public static Pair<Integer,Integer> getResolution(Context ctx){
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      return getRealResolution(ctx);
+    }
+    else {
+      return getRealResolutionOnOldDevice(ctx);
+    }
+  }
+
+  /**
+   * Gets resolution on old devices.
+   * Tries the reflection to get the real resolution first.
+   * Fall back to getDisplayMetrics if the above method failed.
+   * */
+  private static Pair<Integer, Integer> getRealResolutionOnOldDevice(Context ctx) {
+    try{
+      WindowManager wm = (WindowManager) ctx.getSystemService(Context.WINDOW_SERVICE);
+      Display display = wm.getDefaultDisplay();
+      Method mGetRawWidth = Display.class.getMethod("getRawWidth");
+      Method mGetRawHeight = Display.class.getMethod("getRawHeight");
+      Integer realWidth = (Integer) mGetRawWidth.invoke(display);
+      Integer realHeight = (Integer) mGetRawHeight.invoke(display);
+      return new Pair<Integer, Integer>(realWidth, realHeight);
+    }
+    catch (Exception e) {
+      DisplayMetrics disp = ctx.getResources().getDisplayMetrics();
+      return new Pair<Integer, Integer>(disp.widthPixels, disp.heightPixels);
+    }
+  }
+
+  /**
+   * Gets real resolution via the new getRealMetrics API.
+   * */
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+  private static Pair<Integer,Integer> getRealResolution(Context ctx) {
+    WindowManager wm = (WindowManager) ctx.getSystemService(Context.WINDOW_SERVICE);
+    Display display = wm.getDefaultDisplay();
+    DisplayMetrics metrics = new DisplayMetrics();
+    display.getRealMetrics(metrics);
+    return new Pair<Integer, Integer>(metrics.widthPixels, metrics.heightPixels);
+  }
+}

--- a/vitamio/src/io/vov/vitamio/widget/VideoView.java
+++ b/vitamio/src/io/vov/vitamio/widget/VideoView.java
@@ -27,7 +27,7 @@ import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
+import android.util.Pair;
 import android.util.SparseArray;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -49,6 +49,7 @@ import io.vov.vitamio.MediaPlayer.OnVideoSizeChangedListener;
 import io.vov.vitamio.MediaPlayer.TrackInfo;
 import io.vov.vitamio.Vitamio;
 import io.vov.vitamio.utils.Log;
+import io.vov.vitamio.utils.ScreenResolution;
 
 import java.io.IOException;
 import java.util.List;
@@ -313,8 +314,8 @@ public class VideoView extends SurfaceView implements MediaController.MediaPlaye
    */
   public void setVideoLayout(int layout, float aspectRatio) {
     LayoutParams lp = getLayoutParams();
-    DisplayMetrics disp = mContext.getResources().getDisplayMetrics();
-    int windowWidth = disp.widthPixels, windowHeight = disp.heightPixels;
+    Pair<Integer, Integer> res = ScreenResolution.getResolution(mContext);
+    int windowWidth = res.first.intValue(), windowHeight = res.second.intValue();
     float windowRatio = windowWidth / (float) windowHeight;
     float videoRatio = aspectRatio <= 0.01f ? mVideoAspectRatio : aspectRatio;
     mSurfaceHeight = mVideoHeight;


### PR DESCRIPTION
Fixes the black bar for videoview when scaling the video uniformly to full screen mode.

The black bar appears because the DisplayMetrics doesn't return the real device screen height (it minuses the height of the status bar), then we get the wrong aspect ratio of the screen, consequently causes the black bar.

In this pull request I get the real screen resolution via the new getRealMetrics API introduced in API17.  For old devices I tried the reflection method to get the real resolution first and failover to the incorrect resolution which is the value returns by your original method.
